### PR TITLE
Add support for RabbitMQ

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,8 @@
 1.2.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for RabbitMQ
+  [davidonna]
 
 
 1.2.3 (2018-06-10)

--- a/pytest_docker_fixtures/__init__.py
+++ b/pytest_docker_fixtures/__init__.py
@@ -3,9 +3,11 @@ from .containers.es import es_image
 from .containers.etcd import etcd_image
 from .containers.pg import pg_image
 from .containers.redis import redis_image
+from .containers.rabbitmq import rabbitmq_image
 
 import os
 import pytest
+import time
 
 
 IS_TRAVIS = 'TRAVIS' in os.environ
@@ -58,3 +60,9 @@ def etcd():
 def es():
     yield es_image.run()
     es_image.stop()
+
+
+@pytest.fixture(scope='session')
+def rabbitmq():
+    yield rabbitmq_image.run()
+    rabbitmq_image.stop()

--- a/pytest_docker_fixtures/containers/_base.py
+++ b/pytest_docker_fixtures/containers/_base.py
@@ -27,15 +27,18 @@ class BaseImage:
         image_options = self.base_image_options.copy()
         return image_options
 
-    def get_port(self):
+    def get_port(self, port=None):
         if (os.environ.get('TESTING', '') == 'jenkins' or
                 'TRAVIS' in os.environ):
-            return self.port
+            return port if port else self.port
         network = self.container_obj.attrs['NetworkSettings']
-        for port in network['Ports'].keys():
-            if port == '6543/tcp':
+        service_port = '{0}/tcp'.format(port if port else self.port)
+        for netport in network['Ports'].keys():
+            if netport == '6543/tcp':
                 continue
-            return network['Ports'][port][0]['HostPort']
+
+            if netport == service_port:
+                return network['Ports'][service_port][0]['HostPort']
 
     def get_host(self):
         return self.container_obj.attrs['NetworkSettings']['IPAddress']

--- a/pytest_docker_fixtures/containers/rabbitmq.py
+++ b/pytest_docker_fixtures/containers/rabbitmq.py
@@ -1,0 +1,26 @@
+from ._base import BaseImage
+
+import pika
+from pika.connection import URLParameters
+
+
+class RabbitMQ(BaseImage):
+    label = 'rabbitmq'
+    name = 'rabbitmq'
+    port = 5672
+
+    def get_image_options(self):
+        image_options = super().get_image_options()
+        return image_options
+
+    def check(self):
+        url = f'amqp://guest:guest@{self.host}:{self.get_port()}/%2F'
+        try:
+            connection = pika.BlockingConnection(URLParameters(url))
+        except Exception:
+            return False
+        else:
+            return connection.is_open
+
+
+rabbitmq_image = RabbitMQ()

--- a/pytest_docker_fixtures/images.py
+++ b/pytest_docker_fixtures/images.py
@@ -18,6 +18,10 @@ settings = {
     'redis': {
         'image': 'redis',
         'version': '3.2.8'
+    },
+    'rabbitmq': {
+        'image': 'rabbitmq',
+        'version': '3.7.8'
     }
 }
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='pytest-docker-fixtures',
-    version='1.2.4.dev0',
+    version='1.2.5.dev0',
     description='pytest docker fixtures',
     long_description=(open('README.rst').read() + '\n' +
                       open('CHANGELOG.rst').read()),
@@ -33,6 +33,9 @@ setup(
     extras_require={
         'pg': [
             'psycopg2'
+        ],
+        'rabbitmq': [
+            'pika==0.12.0'
         ]
     }
 )


### PR DESCRIPTION
Add support for RabbitMQ

The connection check is done with pika.

BaseImage.get_port() can be called with a 'port' argument
(for the rabbitmq container, because it opens multiple tcp
services, get_port() would fail because it would return the
first container port in the list). This fixes this problem
and allows to get a container's listening port for a port
different than the 'main' service (i hope that was clear ^^)