### PR TITLE
Change psycopg2 dependency to psycopg2-binary

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 1.3.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Change psycopg2 dependency to psycopg2-binary
 
 
 1.3.6 (2020-02-14)

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     ],
     extras_require={
         'pg': [
-            'psycopg2'
+            'psycopg2-binary'
         ],
         'mysql': [
             'mysql-connector-python~=8.0.17'


### PR DESCRIPTION
This fixes installing `pytest-docker-fixtures[pg]` in OSX